### PR TITLE
do not access orm attributes in a dry run

### DIFF
--- a/ella_galleries/migrations/0005_rename_tables_to_ella_galleries_prefix.py
+++ b/ella_galleries/migrations/0005_rename_tables_to_ella_galleries_prefix.py
@@ -12,14 +12,16 @@ class Migration(SchemaMigration):
         db.alter_column('ella_galleries_galleryitem', 'gallery_id', models.ForeignKey(orm['ella_galleries.Gallery'], null=False))
 
         # rename app in contenttypes table
-        orm['contenttypes.contenttype'].objects.filter(app_label='galleries').update(app_label='ella_galleries')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(app_label='galleries').update(app_label='ella_galleries')
 
 
     def backwards(self, orm):
         db.rename_table('ella_galleries_gallery', 'galleries_gallery')
         db.rename_table('ella_galleries_galleryitem', 'galleries_galleryitem')
         # rename app in contenttypes table
-        orm['contenttypes.contenttype'].objects.filter(app_label='ella_galleries').update(app_label='galleries')
+        if not db.dry_run:
+            orm['contenttypes.contenttype'].objects.filter(app_label='ella_galleries').update(app_label='galleries')
 
 
     models = {


### PR DESCRIPTION
Fixing this: Running migration 0005 ends with "AttributeError: You are in a dry run, and cannot access the ORM." 
